### PR TITLE
ci: add 'continuous integration' & 'publish' github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+##
+## Continuous Integration
+##
+## This was intended to run for pull requests that touches `package.json` or
+## the lockfile or any file under `src` directory when using the main branch as
+## the base.
+## Will skip pull requests that starts with "[WIP]" in their title or the ones
+## that are merged already.
+## This workflow aims to detect building errors, test and code coverage failures
+## on pull request's changes.
+##
+
+name: CI - build and test
+
+on:
+  pull_request:
+    branches:
+      - master
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**/*'
+      - 'package*.json'
+
+jobs:
+  automated_tests:
+    name: 'Run tests on ${{ matrix.os }}'
+    timeout-minutes: 10
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    if: >-
+      !startsWith(github.event.pull_request.title, '[WIP]') &&
+      github.event.pull_request.merged == false
+    env:
+      NODE_ENV: 'test'
+    steps:
+      ##########################################################################
+      ######################### Prepare the environment ########################
+      ##########################################################################
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Use LTS version of Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+      - name: Install all dependencies
+        run: npm ci --also=dev
+      ##########################################################################
+      - name: Build the project
+        run: npm run build
+      - name: Run tests
+        run: npm run test
+      - name: Upload HTML coverage report
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'lcov-report-${{ github.event.pull_request.number }}--${{ github.event.pull_request.head.sha }}'
+          if-no-files-found: error
+          path: './coverage/lcov-report'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+##
+## Release
+##
+## This was intended to run for pushes of Git tags that starts with 'v'.
+## This workflows aims to detect building errors and, if there are none,
+## publishes a new version of the package.
+##
+
+name: Publish to NPM
+
+on:
+  push:
+    tags:
+      - 'v*' ## The tag name e.g.: v1.2.3
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      ##########################################################################
+      ######################### Prepare the environment ########################
+      ##########################################################################
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Use node16
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install all dependencies
+        run: npm ci --also=dev
+      ##########################################################################
+      - name: Build the project
+        run: npm run build
+      - name: Publish the package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm --access=public publish

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "tape": "^5.5.2"
   },
   "scripts": {
-    "format:fix": "prettier --write package.json *.markdown src/** test/**",
+    "format:fix": "prettier --write package.json *.markdown src/** test/** **/*.yml",
     "build": "esbuild src/index.js --sourcemap --bundle --minify --outfile=index.js --format=cjs",
     "test": "tap --reporter=base --coverage-report=html test/*.js"
   },


### PR DESCRIPTION
closes #15 

I've added one workflow to run tests and another to just publish. Is it fine? 

---

Also, the `ci.yml` will fail for now because `npm run test` exits with non-zero code due to code coverage report constraints, and I don't believe we should relax that. 

![image](https://user-images.githubusercontent.com/13461315/154816196-d47e9925-0a21-45d1-8f1e-4bbb9568c2a0.png)
 
![image](https://user-images.githubusercontent.com/13461315/154816266-3df7d2a8-5f75-4089-904a-519b0b74254a.png)

![image](https://user-images.githubusercontent.com/13461315/154816247-6e2cad4f-e73b-46c7-8c4b-fafce714edec.png)

![image](https://user-images.githubusercontent.com/13461315/154816253-fb8c6a6c-d570-45eb-ac4e-0a1d507041c6.png)
